### PR TITLE
Use --no-install-recommends when installing dependencies

### DIFF
--- a/toolchain/apt.sh
+++ b/toolchain/apt.sh
@@ -9,7 +9,7 @@ sudo() {
 
 # Install system dependencies.
 sudo apt-get update --yes
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     curl=7.68.0-1ubuntu2.4 \
     default-jdk=2:1.11-72 \
     git=1:2.25.1-1ubuntu3.1 \


### PR DESCRIPTION
- Reduces the size of the runtime image.
- Reduces the number of included dependencies.
- Images with fewer dependencies are faster to build.
- Images that are smaller are faster to push and pull.